### PR TITLE
Fix bug in XML handling; add release notes

### DIFF
--- a/Config.xml
+++ b/Config.xml
@@ -2,7 +2,7 @@
 <Configuration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <Name>FOLIO NCIP Connector</Name>
   <Author>Matthew Connolly, Cornell University Library (mjc12@cornell.edu)</Author>
-  <Version>1.0</Version>
+  <Version>1.0.1</Version>
   <Active>True</Active>
   <Type>System</Type>
   <Description>This add-on sends an NCIP message to FOLIO when a borrowing request is checked in to the receiving library. FOLIO will create a set of associated instance, holding, and item records, suppress them, and create a hold for the item in the specified user's account.</Description>

--- a/folio_ncip_connector.lua
+++ b/folio_ncip_connector.lua
@@ -38,6 +38,8 @@ function make_post_request(address, message)
     if not myWebClient then
         error("Failed to initialize local WebClient");
     end
+    LogDebug("Sending NCIP message to FOLIO at " .. address);
+    LogDebug("Message body: " .. message);
 
     myWebClient.Headers:Add("Content-Type", "application/xml; charset=UTF-8");
     local success, result = pcall(function()
@@ -87,9 +89,9 @@ end
 -- taken from the Transaction object, which is apparently globally accessible.
 function build_accept_item_xml()
     local transaction_no = GetFieldValue('Transaction', 'TransactionNumber');
-    local author = GetFieldValue('Transaction', 'LoanAuthor');
-    local title = GetFieldValue('Transaction', 'LoanTitle');
-    local borrower = GetFieldValue('Transaction', 'Username');
+    local author = encode_special_chars(GetFieldValue('Transaction', 'LoanAuthor'));
+    local title = encode_special_chars(GetFieldValue('Transaction', 'LoanTitle'));
+    local borrower = encode_special_chars(GetFieldValue('Transaction', 'Username'));
     -- NOTE: In ILLiad, the CitedPages field in the Transaction object has been overridden to provide the pickup location.
     -- If it becomes necessary to figure out where another field value is hiding, look up the Transaction database table
     -- fields in the Atlas ILLiad documentation, and maybe use Copilot or ChatGPT to quickly build Lua code to print out
@@ -187,3 +189,16 @@ function get_pickup_location()
 
     return folio_location_code;
 end
+
+-- Function to encode special characters in XML
+function encode_special_chars(input)
+    if input then
+        input = input:gsub("&", "&amp;")
+        input = input:gsub("<", "&lt;")
+        input = input:gsub(">", "&gt;")
+        input = input:gsub("\"", "&quot;")
+        input = input:gsub("'", "&apos;")
+    end
+    return input
+end
+

--- a/release_notes.md
+++ b/release_notes.md
@@ -1,0 +1,10 @@
+# Release notes: illiad-addon-folio-ncip
+
+## [1.0.1] - 2025-02-28
+
+### Added
+- Release notes file
+- Logging of XML message body
+
+### Fixed
+- Error due to improper handling of special characters in XML


### PR DESCRIPTION
The error reported by Caitlin is because of special characters ('&') in the title string of a requested item. I should have handled those properly in the first place.

This also adds a release_notes file and logging of the NCIP message URL and body; since the error messages from WebClient are basically useless, we need all the help we can get!